### PR TITLE
Add CI for Python 3.7, 3.8 & pypy-3.7 via GitHub actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,31 @@
+name: Build and test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', 'pypy-3.7']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r reqs-dev.txt
+      - name: Run tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e py

--- a/reqs-dev.txt
+++ b/reqs-dev.txt
@@ -1,6 +1,6 @@
-mock==1.0.1
+mock>==1.0.1
 pytest>=2.3.7
 pytest-cov>=1.8.0
 pytest-xdist>=1.11
-tox==1.8.1
-iocapture==0.1.2
+tox>=1.8.1
+iocapture>=0.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,pypy
+envlist=py37,py38,pypy
 
 [testenv]
 deps=


### PR DESCRIPTION
A simple PR to update dev dependencies and ensure (via `tox` and GitHub Actions) that the tests run under supported Python versions